### PR TITLE
Update unit tests and support modern Laravel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - hhvm
 
 env:
   - COMPOSER_MEMORY_LIMIT=-1
@@ -31,7 +30,4 @@ before_script:
 script: phpunit
 
 matrix:
-  allow_failures:
-    - php: 5.6
-    - php: hhvm
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 php:
@@ -5,6 +7,10 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
   - hhvm
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ dist: trusty
 
 language: php
 
-env:
-  - COMPOSER_MEMORY_LIMIT=-1
-
 php:
   - 5.4
   - 5.5
@@ -16,9 +13,20 @@ php:
   - 7.4
   - hhvm
 
+env:
+  - COMPOSER_MEMORY_LIMIT=-1
+
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
+  - |
+    if [ "$TRAVIS_PHP_VERSION" == "5.5" ]; then
+      echo using PHPUnit 4.8.36
+      curl -sSfL -o ~/.phpenv/versions/$TRAVIS_PHP_VERSION/bin/phpunit https://phar.phpunit.de/phpunit-4.8.36.phar;
+    elif [ $(echo "$TRAVIS_PHP_VERSION >= 7.2" | bc -l) -eq 1 ]; then
+      echo using PHPUnit 8.5.2
+      curl -sSfL -o ~/.phpenv/versions/$TRAVIS_PHP_VERSION/bin/phpunit https://phar.phpunit.de/phpunit-8.5.2.phar;
+    fi
 
 script: phpunit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ dist: trusty
 
 language: php
 
+env:
+  - COMPOSER_MEMORY_LIMIT=-1
+
 php:
   - 5.4
   - 5.5

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+##########################################################
+####    WhiteSource Integration configuration file    ####
+##########################################################
+
+# Configuration #
+#---------------#
+ws.repo.scan=true
+vulnerable.check.run.conclusion.level=failure

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "email": "vincent.talbot@gmail.com"
     }],
     "require": {
-        "laravel/framework": "~5.0",
+        "laravel/framework": "^5.0",
         "michelf/php-markdown": "^1.8"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "michelf/php-markdown": "^1.8"
     },
     "require-dev": {
-        "mockery/mockery": "0.9.0"
+        "mockery/mockery": "0.9.0",
+        "phpunit/phpunit": "^7"
     },
     "autoload": {
         "psr-4": { "VTalbot\\Markdown\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
         "michelf/php-markdown": "^1.8"
     },
     "require-dev": {
-        "mockery/mockery": "0.9.0",
-        "phpunit/phpunit": "^7"
+        "mockery/mockery": "0.9.0"
     },
     "autoload": {
         "psr-4": { "VTalbot\\Markdown\\": "src/" }

--- a/tests/MarkdownTest.php
+++ b/tests/MarkdownTest.php
@@ -3,7 +3,7 @@
 use Mockery as m;
 use VTalbot\Markdown\Compilers\MarkdownCompiler;
 
-class MarkdownTest extends PHPUnit_Framework_TestCase {
+class MarkdownTest extends PHPUnit\Framework\TestCase {
 
     public function tearDown()
     {

--- a/tests/MarkdownTest.php
+++ b/tests/MarkdownTest.php
@@ -5,7 +5,7 @@ use VTalbot\Markdown\Compilers\MarkdownCompiler;
 
 class MarkdownTest extends PHPUnit\Framework\TestCase {
 
-    public function tearDown()
+    protected function tearDown()
     {
         m::close();
     }

--- a/tests/MarkdownTest.php
+++ b/tests/MarkdownTest.php
@@ -5,10 +5,11 @@ use VTalbot\Markdown\Compilers\MarkdownCompiler;
 
 class MarkdownTest extends PHPUnit\Framework\TestCase {
 
-    protected function tearDown()
-    {
-        m::close();
-    }
+    // Removed for BC.
+    // protected function tearDown()
+    // {
+    //     m::close();
+    // }
 
     public function testTransformString()
     {


### PR DESCRIPTION
I have some legacy projects still using this, but they couldn't be upgraded to Laravel 6 as a result. This should get us over the hurdle.

Continues & replaces #22 